### PR TITLE
fix: pin bitcoin commit hash

### DIFF
--- a/bitcoind.nix
+++ b/bitcoind.nix
@@ -6,8 +6,8 @@
   src = pkgs.fetchFromGitHub {
     owner = "Sjors";
     repo = "bitcoin";
-    rev = "sv2";
-    hash = "sha256-iPVtR06DdheYRfZ/Edm1hu3JLoXAu5obddTQ38cqljs=";
+    rev = "737c02ef0cf36fa5b5f921b3937003bcee6e184d"; # sv2 branch
+    hash = "sha256-OLSCaj1CAK3L29VZIW4ZB4TGD/PLQrUjbctYvtrzzyE=";
   };
 in
   pkgs.bitcoind.overrideAttrs (oldAttrs: {


### PR DESCRIPTION
When I ran `devenv shell`, I got this error

```
devenv shell
• Building shell ...
• Using Cachix: devenv
error: hash mismatch in fixed-output derivation '/nix/store/lj8j0ic0jgrnv2f9rpl7bxq7rhm90d51-source.drv':
         specified: sha256-iPVtR06DdheYRfZ/Edm1hu3JLoXAu5obddTQ38cqljs=
            got:    sha256-OLSCaj1CAK3L29VZIW4ZB4TGD/PLQrUjbctYvtrzzyE=
error: 1 dependencies of derivation '/nix/store/pawxv8wy819mqsijwrq77g97qzmg6s6h-bitcoind-sv2.drv' failed to build
error: 1 dependencies of derivation '/nix/store/7vy8850lq9r0z8vc9895l9vmhpdim7mi-devenv-profile.drv' failed to build
error:
       error: 2 dependencies of derivation '/nix/store/w85984lrp1y2zl9160pg9hc10mz4p7hr-devenv-shell-env.drv' failed to build
```

The error is due to `bitcoind.nix` being pinned to the `sv2` branch in sjors' repo. The hash changes whenever commits get added. I modified the file to pin the [current commit hash](https://github.com/Sjors/bitcoin/commit/737c02ef0cf36fa5b5f921b3937003bcee6e184d). Is there a different commit that should be pinned?