### PR TITLE
flake: add devenv packages to flake outputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,11 @@
       lib = nixpkgs.lib;
     };
   in {
+    packages.${system} = {
+      devenv-up = self.devShells.${system}.default.config.procfileScript;
+      devenv-test = self.devShells.${system}.default.config.test;
+    };
+
     devShells.${system}.default = devenv.lib.mkShell {
       inherit pkgs;
 


### PR DESCRIPTION
per https://devenv.sh/guides/using-with-flakes/#the-flakenix-file
This allows devenv to work with `nix develop --no-pure-eval`. I see you went down the road of modifying the devenv root but this works for me, i can `devenv up` and the processes start.

This seems to throw an `InvalidTaskName` for `create-logs-dir` but the directory seems to be created anyway, and logs are written there, so idk about that.

My main question would be why make this a flake at all? Devenv is for specifying dev environments so idk what flakes give you here, apart from having nix users be ready to roll. 