### PR TITLE
Adds just recipe for modifying cdk commit hash

### DIFF
--- a/justfile
+++ b/justfile
@@ -18,6 +18,15 @@ restore-deps:
         mv "$bakfile" "$origfile"; \
     done
 
+# update cdk commit hash in all Cargo.toml files
+update-cdk OLD_REV NEW_REV:
+    @echo "Updating CDK revision from {{OLD_REV}} to {{NEW_REV}}..."
+    @find . -name "Cargo.toml" | xargs grep -l "cdk.*git.*vnprc.*rev.*{{OLD_REV}}" | while IFS= read -r file; do \
+        echo "✅ Updating $file"; \
+        sed -i 's|rev = "{{OLD_REV}}"|rev = "{{NEW_REV}}"|g' "$file"; \
+    done
+    @echo "Done! CDK updated from {{OLD_REV}} to {{NEW_REV}}"
+
 # update bitcoind.nix with latest rev & hash
 update-bitcoind:
     @echo "Fetching latest commit hash for sv2 branch..."


### PR DESCRIPTION
This PR addresses a comment made in #45 

> When you have committed your changes to the cdk fork and have a commit hash you can run just restore-deps to restore the cargo dependencies to the remote repo. Then do a search and replace across the hashpool repo to update the old commit hash to the new one. Come to think of it, that would make a great just recipe!

It's a simple "search and replace" recipe for modifying the CDK commit hash from its current value to an arbitrary rev.

Example output:

```bash
$ just update-cdk 773af52b f057cc8
Updating CDK revision from 773af52b to f057cc8...
✅ Updating ./roles/mint/Cargo.toml
✅ Updating ./roles/translator/Cargo.toml
✅ Updating ./roles/pool/Cargo.toml
✅ Updating ./protocols/v2/subprotocols/mining/Cargo.toml
Done! CDK updated from 773af52b to f057cc8
```