### PR TITLE
fetch quotes from mint with HTTP client

### DIFF
--- a/protocols/v2/subprotocols/mining/Cargo.toml
+++ b/protocols/v2/subprotocols/mining/Cargo.toml
@@ -19,7 +19,7 @@ serde = { version = "1.0.89", default-features = false, optional= true }
 binary_sv2 = {version = "^1.0.0", path = "../../binary-sv2/binary-sv2" }
 const_sv2 = {version = "^3.0.0", path = "../../const-sv2"}
 derive_codec_sv2 = {version = "^1.0.0", path = "../../../../protocols/v2/binary-sv2/no-serde-sv2/derive_codec"}
-cdk = { git = "https://github.com/vnprc/cdk", rev = "773af52b" }
+cdk = { git = "https://github.com/vnprc/cdk", rev = "64ec7f6f" }
 serde_json = "1.0"
 tracing = { version = "0.1" }
 

--- a/roles/Cargo.lock
+++ b/roles/Cargo.lock
@@ -902,7 +902,7 @@ dependencies = [
 [[package]]
 name = "cashu"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "bitcoin 0.32.6",
  "bitcoin_hashes 0.16.0",
@@ -953,7 +953,7 @@ dependencies = [
 [[package]]
 name = "cdk"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -982,15 +982,17 @@ dependencies = [
 [[package]]
 name = "cdk-axum"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "async-trait",
  "axum",
  "cdk",
+ "cdk-common",
  "futures",
  "moka",
  "paste",
+ "redis 0.23.3",
  "serde",
  "serde_json",
  "sha2 0.10.9",
@@ -1002,7 +1004,7 @@ dependencies = [
 [[package]]
 name = "cdk-cln"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "async-trait",
  "bitcoin 0.32.6",
@@ -1019,7 +1021,7 @@ dependencies = [
 [[package]]
 name = "cdk-common"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1042,7 +1044,7 @@ dependencies = [
 [[package]]
 name = "cdk-fake-wallet"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "async-trait",
  "bitcoin 0.32.6",
@@ -1061,7 +1063,7 @@ dependencies = [
 [[package]]
 name = "cdk-lnbits"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1079,7 +1081,7 @@ dependencies = [
 [[package]]
 name = "cdk-lnd"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1095,7 +1097,7 @@ dependencies = [
 [[package]]
 name = "cdk-mint-rpc"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "cdk",
@@ -1115,7 +1117,7 @@ dependencies = [
 [[package]]
 name = "cdk-mintd"
 version = "0.7.2"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "axum",
@@ -1148,7 +1150,7 @@ dependencies = [
 [[package]]
 name = "cdk-phoenixd"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1167,7 +1169,7 @@ dependencies = [
 [[package]]
 name = "cdk-redb"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "async-trait",
  "cdk-common",
@@ -1183,7 +1185,7 @@ dependencies = [
 [[package]]
 name = "cdk-sqlite"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "async-trait",
  "bitcoin 0.32.6",
@@ -1200,7 +1202,7 @@ dependencies = [
 [[package]]
 name = "cdk-strike"
 version = "0.7.1"
-source = "git+https://github.com/vnprc/cdk?rev=773af52b#773af52b5977efa53fa4d094134425270497e422"
+source = "git+https://github.com/vnprc/cdk?rev=64ec7f6f#64ec7f6f8681fc3707a0f5e023fcdb2fa0a60a5e"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3962,10 +3964,13 @@ dependencies = [
  "itoa",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.12",
+ "rustls-native-certs 0.6.3",
  "ryu",
  "sha1_smol",
  "socket2 0.4.10",
  "tokio",
+ "tokio-rustls 0.24.1",
  "tokio-util",
  "url",
 ]

--- a/roles/mint/Cargo.toml
+++ b/roles/mint/Cargo.toml
@@ -17,11 +17,11 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 bitcoin = { version= "0.32.2" }
 
-cdk = { git = "https://github.com/vnprc/cdk.git", package = "cdk", rev = "773af52b" }
-cdk-axum = { git = "https://github.com/vnprc/cdk.git", package = "cdk-axum", rev = "773af52b" }
-cdk-mintd = { git = "https://github.com/vnprc/cdk.git", package = "cdk-mintd", rev = "773af52b" }
-cdk-sqlite = { git = "https://github.com/vnprc/cdk.git", package = "cdk-sqlite", rev = "773af52b" }
-cdk-redb = { git = "https://github.com/vnprc/cdk.git", package = "cdk-redb", rev = "773af52b" }
+cdk = { git = "https://github.com/vnprc/cdk.git", package = "cdk", rev = "64ec7f6f" }
+cdk-axum = { git = "https://github.com/vnprc/cdk.git", package = "cdk-axum", rev = "64ec7f6f", features = ["redis"]}
+cdk-mintd = { git = "https://github.com/vnprc/cdk.git", package = "cdk-mintd", rev = "64ec7f6f" }
+cdk-sqlite = { git = "https://github.com/vnprc/cdk.git", package = "cdk-sqlite", rev = "64ec7f6f" }
+cdk-redb = { git = "https://github.com/vnprc/cdk.git", package = "cdk-redb", rev = "64ec7f6f" }
 toml = "0.8.22"
 
 shared_config = { path = "../roles-utils/config" }

--- a/roles/pool/Cargo.toml
+++ b/roles/pool/Cargo.toml
@@ -39,7 +39,7 @@ key-utils = { version = "^1.0.0", path = "../../utils/key-utils" }
 bip39 = { version = "2.0", features = ["rand"] }
 mining_sv2 = { version = "^1.0.0", path = "../../protocols/v2/subprotocols/mining" }
 bitcoin = { version= "0.32.2" }
-cdk = { git = "https://github.com/vnprc/cdk", rev = "773af52b" }
+cdk = { git = "https://github.com/vnprc/cdk", rev = "64ec7f6f" }
 bitcoin_hashes = { version = "0.16", features = ["serde"] }
 redis = { version = "0.25", features = ["tokio-comp"] }
 shared_config = { path = "../roles-utils/config" }

--- a/roles/translator/Cargo.toml
+++ b/roles/translator/Cargo.toml
@@ -46,7 +46,7 @@ async-compat = "0.2.1"
 rand = "0.8.4"
 bitcoin = "0.30"
 mining_sv2 = { version = "^1.0.0", path = "../../protocols/v2/subprotocols/mining" }
-cdk = { git = "https://github.com/vnprc/cdk", rev = "773af52b" }
+cdk = { git = "https://github.com/vnprc/cdk", rev = "64ec7f6f" }
 uuid = { version = "1", features = ["v4"] }
 ureq = { version = "2", features = ["tls"] }
 # TODO delete after implementing the cdk HTTP API to retrieve quote id from header hash


### PR DESCRIPTION
This PR replaces https://github.com/vnprc/hashpool/pull/47 as that branch fell out of sync with master.

Note: this is dependent on https://github.com/vnprc/cdk/pull/2.

Addresses https://github.com/vnprc/hashpool/issues/45

This PR adds a method for fetching a batch of quote IDs from the mint via an HTTP Get request instead of reading from Redis directly.

Steps to get it running:

- `export CDK_PATH=/path/to/cdk/repo/crates/cdk/`
- `just local-cdk`
- add the redis feature to the cdk-axum import in the mint Cargo.toml `cdk-axum = { path = "$CDK_PATH/cdk-axum", features = ["redis"] }`
- `devenv up`
