### PR TITLE
Migrate from testnet4 to regtest

### DIFF
--- a/bitcoin.conf
+++ b/bitcoin.conf
@@ -1,9 +1,9 @@
 server=1
 rpcuser=username
 rpcpassword=password
-testnet4=1
+regtest=1
 
-[testnet4]
+[regtest]
 sv2=1
 sv2port=8442
 debug=sv2

--- a/devenv.nix
+++ b/devenv.nix
@@ -97,6 +97,11 @@ in {
         bitcoind -datadir=${bitcoindDataDir} -conf=${config.devenv.root}/bitcoin.conf
       '' "bitcoind-regtest.log";
     };
+    bitcoind-setup = {
+      exec = withLogging ''
+        DEVENV_ROOT=${config.devenv.root} BITCOIND_DATADIR=${bitcoindDataDir} ${config.devenv.root}/scripts/bitcoind-setup.sh
+      '' "bitcoind-setup.log";
+    };
     miner = {
       exec = withLogging ''
         echo "Waiting for proxy..."

--- a/devenv.nix
+++ b/devenv.nix
@@ -95,7 +95,7 @@ in {
       exec = withLogging ''
         mkdir -p ${bitcoindDataDir}
         bitcoind -datadir=${bitcoindDataDir} -conf=${config.devenv.root}/bitcoin.conf
-      '' "bitcoind-testnet.log";
+      '' "bitcoind-regtest.log";
     };
     miner = {
       exec = withLogging ''

--- a/justfile
+++ b/justfile
@@ -41,14 +41,7 @@ update-bitcoind:
     sed -i "s|hash = \".*\";|hash = \"$HASH\";|" bitcoind.nix && \
     echo "Done! bitcoind updated to commit $LATEST_COMMIT\nYou are now ready to test and commit"
 
-# create regtest wallet if it doesn't exist
-create-wallet:
-    @echo "Creating regtest wallet..."
-    @bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest createwallet "regtest" || \
-    (echo "Wallet exists, loading..." && bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest loadwallet "regtest")
-
 # generate blocks in regtest
-generate-blocks COUNT="1" CREATE_WALLET="false":
+generate-blocks COUNT="1":
     @echo "Generating {{COUNT}} blocks in regtest..."
-    @if [ "{{CREATE_WALLET}}" = "true" ]; then just create-wallet; fi
     @bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest -rpcwallet=regtest -generate {{COUNT}}

--- a/justfile
+++ b/justfile
@@ -40,3 +40,21 @@ update-bitcoind:
     sed -i "s|rev = \".*\";|rev = \"$LATEST_COMMIT\";|" bitcoind.nix && \
     sed -i "s|hash = \".*\";|hash = \"$HASH\";|" bitcoind.nix && \
     echo "Done! bitcoind updated to commit $LATEST_COMMIT\nYou are now ready to test and commit"
+
+# create regtest wallet if it doesn't exist
+create-wallet:
+    @echo "Creating regtest wallet..."
+    @bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest createwallet "regtest" || \
+    (echo "Wallet exists, loading..." && bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest loadwallet "regtest")
+
+# generate blocks in regtest
+generate-blocks COUNT="1" CREATE_WALLET="false":
+    @echo "Generating {{COUNT}} blocks in regtest..."
+    @if [ "{{CREATE_WALLET}}" = "true" ]; then just create-wallet; fi
+    @bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest -rpcwallet=regtest -generate {{COUNT}}
+
+# generate blocks to a specific address in regtest
+generate-to-address ADDRESS COUNT="1" CREATE_WALLET="false":
+    @echo "Generating {{COUNT}} blocks to address {{ADDRESS}} in regtest..."
+    @if [ "{{CREATE_WALLET}}" = "true" ]; then just create-wallet; fi
+    @bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest -rpcwallet=regtest generatetoaddress {{COUNT}} {{ADDRESS}}

--- a/justfile
+++ b/justfile
@@ -52,9 +52,3 @@ generate-blocks COUNT="1" CREATE_WALLET="false":
     @echo "Generating {{COUNT}} blocks in regtest..."
     @if [ "{{CREATE_WALLET}}" = "true" ]; then just create-wallet; fi
     @bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest -rpcwallet=regtest -generate {{COUNT}}
-
-# generate blocks to a specific address in regtest
-generate-to-address ADDRESS COUNT="1" CREATE_WALLET="false":
-    @echo "Generating {{COUNT}} blocks to address {{ADDRESS}} in regtest..."
-    @if [ "{{CREATE_WALLET}}" = "true" ]; then just create-wallet; fi
-    @bitcoin-cli -datadir=.devenv/state/bitcoind -conf=$(pwd)/bitcoin.conf -rpcuser=username -rpcpassword=password -regtest -rpcwallet=regtest generatetoaddress {{COUNT}} {{ADDRESS}}

--- a/protocols/v2/roles-logic-sv2/src/job_creator.rs
+++ b/protocols/v2/roles-logic-sv2/src/job_creator.rs
@@ -524,7 +524,7 @@ pub mod tests {
     }
 
     const PRIVATE_KEY_BTC: [u8; 32] = [34; 32];
-    const NETWORK: Network = Network::Testnet;
+    const NETWORK: Network = Network::Regtest;
 
     #[cfg(feature = "prop_test")]
     const BLOCK_REWARD: u64 = 625_000_000_000;

--- a/roles/jd-server/config-examples/jds-config-local-example.toml
+++ b/roles/jd-server/config-examples/jds-config-local-example.toml
@@ -22,7 +22,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 # RPC config for mempool (it can be also the same TP if correctly configured)
 core_rpc_url =  "http://127.0.0.1"
-core_rpc_port = 48332
+core_rpc_port = 18443
 core_rpc_user =  "username"
 core_rpc_pass =  "password"
 # Time interval used for JDS mempool update 

--- a/scripts/bitcoind-setup.sh
+++ b/scripts/bitcoind-setup.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+# bitcoind-setup.sh - Initialize regtest environment
+# This script waits for bitcoind to be ready, then checks if we need to initialize
+# the regtest environment with a wallet and some initial blocks. This should only
+# need to be run once per dev environment setup or if you've reset your state. It's
+# idempotent, so you can safely run it multiple times.
+
+set -e
+
+BITCOIN_CONF="${DEVENV_ROOT:-$(pwd)}/bitcoin.conf"
+DATADIR="${BITCOIND_DATADIR:-$(pwd)/.devenv/state/bitcoind}"
+RPC_ARGS="-datadir=${DATADIR} -conf=${BITCOIN_CONF} -rpcuser=username -rpcpassword=password -regtest"
+
+create_and_load_wallet() {
+    echo "Creating/loading regtest wallet..."
+    if ! bitcoin-cli $RPC_ARGS createwallet "regtest" 2>/dev/null; then
+        echo "Wallet exists, attempting to load..."
+        bitcoin-cli $RPC_ARGS loadwallet "regtest" 2>/dev/null || echo "Wallet already loaded"
+    fi
+}
+
+echo "Waiting for bitcoind to be ready..."
+
+# Wait for bitcoind RPC to be available
+max_attempts=30
+attempt=0
+while [ $attempt -lt $max_attempts ]; do
+    if bitcoin-cli $RPC_ARGS getblockchaininfo >/dev/null 2>&1; then
+        echo "bitcoind is ready!"
+        break
+    fi
+    attempt=$((attempt + 1))
+    echo "Attempt $attempt/$max_attempts: bitcoind not ready yet, waiting..."
+    sleep 2
+done
+
+if [ $attempt -eq $max_attempts ]; then
+    echo "ERROR: bitcoind failed to become ready after $max_attempts attempts"
+    exit 1
+fi
+
+BLOCK_HEIGHT=$(bitcoin-cli $RPC_ARGS getblockcount 2>/dev/null || echo "0")
+echo "Current block height: $BLOCK_HEIGHT"
+
+# Ensure we have at least 16 blocks and a wallet
+if [ "$BLOCK_HEIGHT" -lt "16" ]; then
+    BLOCKS_NEEDED=$((16 - BLOCK_HEIGHT))
+    echo "Block height is $BLOCK_HEIGHT, need to generate $BLOCKS_NEEDED more blocks..."
+
+    create_and_load_wallet
+
+    echo "Generating $BLOCKS_NEEDED blocks to reach height 16..."
+    bitcoin-cli $RPC_ARGS -rpcwallet=regtest -generate $BLOCKS_NEEDED
+
+    NEW_HEIGHT=$(bitcoin-cli $RPC_ARGS getblockcount)
+    echo "✅ Regtest environment initialized! New block height: $NEW_HEIGHT"
+else
+    echo "✅ Regtest environment already has sufficient blocks (height: $BLOCK_HEIGHT)"
+
+    create_and_load_wallet
+fi
+
+echo "bitcoind setup complete!"

--- a/test/config/interop-jd-change-upstream/jds-config.toml
+++ b/test/config/interop-jd-change-upstream/jds-config.toml
@@ -11,7 +11,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 
 core_rpc_url =  ""
-core_rpc_port = 18332
+core_rpc_port = 18443
 core_rpc_user =  ""
 core_rpc_pass =  ""
 # Time interval used for JDS mempool update 

--- a/test/config/interop-jd-translator/jdc-config.toml
+++ b/test/config/interop-jd-translator/jdc-config.toml
@@ -25,9 +25,9 @@ retry = 10
 
 # Template Provider config
 # Local TP (this is pointing to localhost so you must run a TP locally for this configuration to work)
-# tp_address = "127.0.0.1:8442"
-# Hosted testnet TP 
-tp_address = "75.119.150.111:8442"
+tp_address = "127.0.0.1:8442"
+# Hosted testnet TP
+# tp_address = "75.119.150.111:8442"
 tp_authority_pub_key = "9auqWEzQDVyd2oe1JVGFLMLHZtCo2FFqZwtKA5gd9xbuEu7PH72"
 
 # Solo Mining config

--- a/test/config/interop-jd-translator/jds-config.toml
+++ b/test/config/interop-jd-translator/jds-config.toml
@@ -11,7 +11,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 
 core_rpc_url =  ""
-core_rpc_port = 18332
+core_rpc_port = 18443
 core_rpc_user =  ""
 core_rpc_pass =  ""
 # Time interval used for JDS mempool update 

--- a/test/config/interop-jd-translator/pool-config.toml
+++ b/test/config/interop-jd-translator/pool-config.toml
@@ -19,5 +19,5 @@ coinbase_outputs = [
 pool_signature = "Stratum v2 SRI Pool - gitgab19"
 
 # Template Provider config
-# hosted testnet TP 
-tp_address = "75.119.150.111:8442"
+# Local TP for regtest
+tp_address = "127.0.0.1:8442"

--- a/test/config/jds-do-not-fail-on-wrong-txdatasucc/jds-config.toml
+++ b/test/config/jds-do-not-fail-on-wrong-txdatasucc/jds-config.toml
@@ -11,7 +11,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 
 core_rpc_url =  ""
-core_rpc_port = 18332
+core_rpc_port = 18443
 core_rpc_user =  ""
 core_rpc_pass =  ""
 # Time interval used for JDS mempool update 

--- a/test/config/jds-do-not-panic-if-jdc-close-connection/jds-config.toml
+++ b/test/config/jds-do-not-panic-if-jdc-close-connection/jds-config.toml
@@ -11,7 +11,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 
 core_rpc_url =  ""
-core_rpc_port = 18332
+core_rpc_port = 18443
 core_rpc_user =  ""
 core_rpc_pass =  ""
 # Time interval used for JDS mempool update 

--- a/test/config/jds-receive-solution-while-processing-declared-job/jds-config.toml
+++ b/test/config/jds-receive-solution-while-processing-declared-job/jds-config.toml
@@ -11,7 +11,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 
 core_rpc_url =  ""
-core_rpc_port = 48332
+core_rpc_port = 18443
 core_rpc_user =  ""
 core_rpc_pass =  ""
 # Time interval used for JDS mempool update 

--- a/test/config/jds-setupconnection-flag-test/jds-config-with-async-support.toml
+++ b/test/config/jds-setupconnection-flag-test/jds-config-with-async-support.toml
@@ -14,7 +14,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 
 core_rpc_url =  ""
-core_rpc_port = 18332
+core_rpc_port = 18443
 core_rpc_user =  ""
 core_rpc_pass =  ""
 # Time interval used for JDS mempool update 

--- a/test/config/jds-setupconnection-flag-test/jds-config-without-async-support.toml
+++ b/test/config/jds-setupconnection-flag-test/jds-config-without-async-support.toml
@@ -14,7 +14,7 @@ coinbase_outputs = [
 listen_jd_address = "127.0.0.1:34264"
 
 core_rpc_url =  ""
-core_rpc_port = 18332
+core_rpc_port = 18443
 core_rpc_user =  ""
 core_rpc_pass =  ""
 # Time interval used for JDS mempool update 


### PR DESCRIPTION
Closes https://github.com/vnprc/hashpool/issues/7

This PR:
- migrates from testnet4 to regtest
- adds `just` recipes for:
  -  mining N blocks
  - creating a wallet

We need a wallet in order to generate blocks, so it also includes a setup script to ensure that a wallet exists and we have at least 16 blocks.